### PR TITLE
Change tap to npx tap

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -76,7 +76,7 @@ export default class Runner {
     }
 
     private getCommand(filePath: string | null): string {
-        return `tap ${filePath}`;
+        return `npx tap ${filePath}`;
     }
 
     private runCommand(command: string) {


### PR DESCRIPTION
Not all machines have `tap` as something that can be typed in the command line. npx tap will guarantee that tap will be ran, even on machines where tap is not in $PATH.

for what its worth, npx does detect if `tap` is available in $PATH, and just runs that, so this isn't a performance hit.